### PR TITLE
fix: Remove invalid type comparison between string and number

### DIFF
--- a/lib/merkle/verifier.ts
+++ b/lib/merkle/verifier.ts
@@ -71,7 +71,7 @@ export function validateDistribution(distribution: DistributionData[]): Validati
   const invalidAmounts = distribution.filter((d, index) => {
     try {
       // Handle different amount formats
-      if (!d.amount && d.amount !== 0 && d.amount !== '0') {
+      if (!d.amount && d.amount !== '0') {
         console.warn(`[validateDistribution] Missing amount at index ${index}`);
         return true; // Missing amount
       }


### PR DESCRIPTION
## Summary
- Fixed TypeScript build error where `amount` (string type) was incorrectly being compared to numeric `0`
- The validation now correctly checks only string comparisons while preserving the logic for empty/missing amounts

## Test plan
- [x] Build completes successfully without TypeScript errors
- [x] Validation logic still correctly handles:
  - Empty/missing amounts
  - String '0' as valid value  
  - Negative values
  - Invalid BigInt formats

🤖 Generated with [Claude Code](https://claude.ai/code)