### PR TITLE
fix: Resolve TypeScript type error in merkle verifier

### DIFF
--- a/lib/merkle/verifier.ts
+++ b/lib/merkle/verifier.ts
@@ -29,7 +29,7 @@ export async function verifyMerkleRoot(
       console.log('[verifyMerkleRoot] ParaSwap fields detected, trying paraswap format first');
     }
     
-    detectedFormat = detectMerkleFormat(distribution, expectedRoot);
+    detectedFormat = detectMerkleFormat(distribution, expectedRoot) ?? undefined;
     
     if (!detectedFormat) {
       // If no format matched, try paraswap if fields suggest it


### PR DESCRIPTION
## Summary
- Fixed TypeScript compilation error that was causing build failures on Railway deployment
- Resolved type mismatch where `detectMerkleFormat()` returns `MerkleFormat | null` but the variable expected `MerkleFormat | undefined`

## Changes
- Added nullish coalescing operator (`??`) to convert `null` to `undefined` in `/lib/merkle/verifier.ts:32`

## Test plan
- [x] TypeScript compilation passes without errors
- [x] Build completes successfully with `npm run build`
- [x] No runtime behavior changes - this is purely a type compatibility fix

🤖 Generated with [Claude Code](https://claude.ai/code)